### PR TITLE
add support for seek URLs in the GitHub files changed view

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Vibinex Code Review",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "manifest_version": 3,
     "description": "Personalization and context for pull requests on GitHub & Bitbucket",
     "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsRm6EaBdHDBxVjt9o9WKeL9EDdz1X+knDAU5uoZaRsXTmWjslhJN9DhSd7/Ys4aJOSN+s+5/HnIHcKV63P4GYaUM5FhETHEWORHlwIgjcV/1h6wD6bNbvXi06gtiygE+yMrCzzD93/Z+41XrwMElYiW2U5owNpat2Yfq4p9FDX1uBJUKsRIMp6LbRQla4vAzH/HMUtHWmeuUsmPVzcq1b6uB1QmuJqIQ1GrntIHw3UBWUlqRZ5OtxI1DCP3knglvqz26WT5Pc4GBDNlcI9+3F0vhwqwHqrdyjZpIKZ7iaQzcrovOqUKuXs1J3hDtXq8WoJELIqfIisY7rhAvq6b8jQIDAQAB",

--- a/scripts/orchestrator.js
+++ b/scripts/orchestrator.js
@@ -73,8 +73,8 @@ const orchestrator = async (tabUrl, websiteUrl, userId) => {
 				triggerBtnMutationObserver.disconnect();
 				triggerBtnMutationObserver = null;
 			}
-			
-			if (urlObj[5] === "pull" && urlObj[6] && urlObj[7] === "files") {
+
+			if (urlObj[5] === "pull" && urlObj[6] && !Number.isNaN(parseInt(urlObj[6])) && urlObj[7].startsWith('files')) {
 				const prNumber = parseInt(urlObj[6]);
 				const body = {
 					"repo_owner": ownerName,


### PR DESCRIPTION
Basically, handle URLs that look like 
`https://github.com/vibinex/vibinex-server/pull/409/files#diff-537ba17105f494abbb14c4a3fe7ec5d9cb681fe562ae099a2c3a6ca61ae7369eR35`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved URL parameter validation to enhance the robustness of the app’s functionality.
	- Added additional checks to ensure URL parameters are in the expected format and type before further processing.
- **Chores**
	- Updated the version number in the project manifest to indicate a minor update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->